### PR TITLE
added the futures data option

### DIFF
--- a/backend/stock-data/main.py
+++ b/backend/stock-data/main.py
@@ -3,6 +3,7 @@ import json
 
 import pandas as pd
 import yfinance as yf
+from yahoofinancials import YahooFinancials
 from fastapi import FastAPI
 
 app = FastAPI()
@@ -84,3 +85,14 @@ async def get_data_options(ticker: str):
     options = options.to_json(orient="records")
 
     return options
+
+
+@app.get("/stock/futures-data/{ticker}")
+async def get_futures_data(ticker: str):
+    yahoo_financials_commodities = YahooFinancials(ticker)
+    daily_commodity_prices = yahoo_financials_commodities.get_historical_price_data(
+    '2008-09-15', '2018-09-15', 'daily')
+
+    futures_data = json.dumps(daily_commodity_prices, indent=4)
+
+    return futures_data


### PR DESCRIPTION
## Purpose
The feature I added is to get the futures data of the commodity. This issue is linked to #11 

## Approach
I have used the yahoofinanacials module because yfinance does not support the futures option

#### Open Questions and Pre-Merge TODOs
- [ ] Does your code affect the documentation
- [ ] Have you updated the readme as per your change in code
- [x] Did you followed the code of conduct
- [x] Did you follow the contribution guidelines


## Learning
I have used the below materials to solve the issue
https://github.com/JECSand/yahoofinancials
https://pypi.org/project/yahoofinancials/

##Output
The Futures data will be shown as follows when we give the commodity (eg. 'CL=F','GC=F', 'SI=F')
`{
    "CL=F": {
        "eventsData": {},
        "firstTradeDate": {
            "formatted_date": "2000-08-23",
            "date": 967003200
        },
        "currency": "USD",
        "instrumentType": "FUTURE",
        "timeZone": {
            "gmtOffset": -18000
        },
        "prices": [
            {
                "date": 1221451200,
                "high": 101.19000244140625,
                "low": 94.0,
                "open": 101.0,
                "close": 95.70999908447266,
                "volume": 334900,
                "adjclose": 95.70999908447266,
                "formatted_date": "2008-09-15"
            },
            {
                "date": 1221537600,
                "high": 94.31999969482422,
                "low": 90.51000213623047,
                "open": 94.2300033569336,
                "close": 91.1500015258789,
                "volume": 327157,
                "adjclose": 91.1500015258789,
                "formatted_date": "2008-09-16"
            },..........`

